### PR TITLE
Migrate from annotations to PodMonitor for metrics

### DIFF
--- a/redis/templates/deployment.yaml
+++ b/redis/templates/deployment.yaml
@@ -16,11 +16,6 @@ spec:
       service: "redis"
   template:
     metadata:
-      annotations:
-        {{ if .Values.metrics.enabled }}
-        prometheus.io.scrape: "true"
-        prometheus.io.port: "9121"
-        {{ end }}
       labels:
         service: "redis"
     spec:
@@ -65,7 +60,8 @@ spec:
         - name: "redis-exporter"
           image: "oliver006/redis_exporter:v0.14"
           ports:
-          - containerPort: 9121
+          - name: metrics
+            containerPort: 9121
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}
         {{ end }}

--- a/redis/templates/podmonitor.yaml
+++ b/redis/templates/podmonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: redis
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      service: redis
+  podMetricsEndpoints:
+    - port: metrics


### PR DESCRIPTION
Migrate from annotations to PodMonitor for adding metrics.

* Remove old way of doing Prometheus annotations from `redis/templates/deployment.yaml`.
* Add a named port "metrics" to the `redis-exporter` container in `redis/templates/deployment.yaml` so that prom can find it hopefully.
* Add a new `redis/templates/podmonitor.yaml` file to define the PodMonitor custom resource.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/favish/helm-redis/pull/2?shareId=fb922c3c-f73f-4018-8f70-4b21b06e54f9).